### PR TITLE
fix: update gha ci tagging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,6 +103,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test, security, cdk-synthesis]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    permissions:
+      contents: write
+      packages: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v5


### PR DESCRIPTION
- handles permission related error